### PR TITLE
[Cirrus-37] Replaced sat-search with pystac-client

### DIFF
--- a/core/add-collections/requirements.txt
+++ b/core/add-collections/requirements.txt
@@ -1,2 +1,3 @@
 cirrus-lib~=0.4
 pystac~=0.5
+pystac-client~=0.1.1

--- a/core/api/requirements.txt
+++ b/core/api/requirements.txt
@@ -1,1 +1,2 @@
 cirrus-lib~=0.4
+pystac-client~=0.1.1

--- a/core/process/requirements.txt
+++ b/core/process/requirements.txt
@@ -1,1 +1,2 @@
 cirrus-lib~=0.4
+pystac-client~=0.1.1

--- a/core/publish-test/requirements.txt
+++ b/core/publish-test/requirements.txt
@@ -1,1 +1,2 @@
 cirrus-lib~=0.4
+pystac-client~=0.1.1


### PR DESCRIPTION
I removed the sat-search requirement and replaced it with pystac-client. In addition to this, I also added pystac-client to all of the core lambdas as I see there are plans to implement it in issue #34.